### PR TITLE
Upgrade ECharts from v5.5 to v6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@solid-primitives/resize-observer": "^2.0.26"
   },
   "peerDependencies": {
-    "echarts": "^5.5.1",
+    "echarts": "^6.1.0",
     "solid-js": "^1.8.22"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ dependencies:
     specifier: ^2.0.26
     version: 2.0.26(solid-js@1.8.22)
   echarts:
-    specifier: ^5.5.1
-    version: 5.5.1
+    specifier: ^6.1.0
+    version: 6.1.0
 
 devDependencies:
   '@typescript-eslint/eslint-plugin':
@@ -1710,11 +1710,11 @@ packages:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
     dev: true
 
-  /echarts@5.5.1:
-    resolution: {integrity: sha512-Fce8upazaAXUVUVsjgV6mBnGuqgO+JNDlcgF79Dksy4+wgGpQB2lmYoO4TSweFg/mZITdpGHomw/cNBJZj1icA==}
+  /echarts@6.1.0:
+    resolution: {integrity: sha512-q0yaFPggC9FUdsWH4blavRWFmxdrIodbkoKNAjJudAI6CA9gNPxHtV2RcZNEepZVlk4yvBYkOkbk6HIVpIyHZA==}
     dependencies:
       tslib: 2.3.0
-      zrender: 5.6.0
+      zrender: 6.1.0
     dev: false
 
   /electron-to-chromium@1.5.13:
@@ -3497,8 +3497,8 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  /zrender@5.6.0:
-    resolution: {integrity: sha512-uzgraf4njmmHAbEUxMJ8Oxg+P3fT04O+9p7gY+wJRVxo8Ge+KmYv0WJev945EH4wFuc4OY2NLXz46FZrWS9xJg==}
+  /zrender@6.1.0:
+    resolution: {integrity: sha512-oEGMDB6pOP2S6OwRR4PdVv610zrjnA3Bh+JnSG12fYJlBKjtNAoEb5fSUoCOOINlH96I2fU38/A2UpRKs67xYQ==}
     dependencies:
       tslib: 2.3.0
     dev: false


### PR DESCRIPTION
A brief test suggests that this package continues to work without modification.